### PR TITLE
Add Next.js AdminPanel with role check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Energy-Bill-System
+
+This project now includes a minimal Next.js setup.
+
+## Development
+
+Install dependencies (requires network access):
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+## AdminPanel
+
+`pages/AdminPanel.js` is protected. The page checks a cookie named `role` and only allows access when its value is `developer`. Other users are redirected to the front page.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "energy-bill-system",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "cookie": "0.5.0"
+  }
+}

--- a/pages/AdminPanel.js
+++ b/pages/AdminPanel.js
@@ -1,0 +1,26 @@
+import { parse } from 'cookie';
+
+export async function getServerSideProps({ req }) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  const role = cookies.role;
+
+  if (role !== 'developer') {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+
+  return { props: {} };
+}
+
+export default function AdminPanel() {
+  return (
+    <main>
+      <h1>Admin Panel</h1>
+      <p>Only for developers.</p>
+    </main>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Home Page</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- set up a minimal Next.js project
- add protected `AdminPanel` page
- add a simple home page
- document how to use the project

## Testing
- `npm run build` *(fails: `next` not found)*