### PR TITLE
Replace Firebase auth with local email login

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,12 @@
+{
+  "users": [
+    {
+      "id": 1,
+      "email": "admin@example.com",
+      "passwordHash": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918",
+      "groups": ["admin"]
+    }
+  ],
+  "groups": ["admin"],
+  "sessions": {}
+}

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+
+const DATA_PATH = path.join(process.cwd(), 'data.json');
+
+function readData() {
+  if (!fs.existsSync(DATA_PATH)) {
+    return { users: [], groups: [], sessions: {} };
+  }
+  const text = fs.readFileSync(DATA_PATH, 'utf-8');
+  return JSON.parse(text);
+}
+
+function writeData(data) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+export function getUsers() {
+  return readData().users;
+}
+
+export function findUserByEmail(email) {
+  const data = readData();
+  return data.users.find(u => u.email === email) || null;
+}
+
+export function addUser(email, passwordHash, groups = []) {
+  const data = readData();
+  const id = data.users.reduce((max, u) => Math.max(max, u.id), 0) + 1;
+  data.users.push({ id, email, passwordHash, groups });
+  writeData(data);
+  return id;
+}
+
+export function getGroups() {
+  return readData().groups;
+}
+
+export function addGroup(name) {
+  const data = readData();
+  if (!data.groups.includes(name)) {
+    data.groups.push(name);
+    writeData(data);
+  }
+}
+
+export function createSession(userId, token) {
+  const data = readData();
+  data.sessions[token] = userId;
+  writeData(data);
+}
+
+export function getSession(token) {
+  const data = readData();
+  return data.sessions[token] || null;
+}
+
+export function deleteSession(token) {
+  const data = readData();
+  delete data.sessions[token];
+  writeData(data);
+}

--- a/pages/AdminPanel.js
+++ b/pages/AdminPanel.js
@@ -1,26 +1,75 @@
 import { parse } from 'cookie';
+import { getSession, getUsers, getGroups } from '../lib/data.js';
 
 export async function getServerSideProps({ req }) {
   const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
-  const role = cookies.role;
+  const token = cookies.session;
+  const userId = getSession(token);
+  const user = getUsers().find(u => u.id === userId);
 
-  if (role !== 'developer') {
+  if (!user || !user.groups.includes('admin')) {
     return {
       redirect: {
-        destination: '/',
+        destination: '/login',
         permanent: false,
       },
     };
   }
 
-  return { props: {} };
+  return { props: { groups: getGroups() } };
 }
 
-export default function AdminPanel() {
+export default function AdminPanel({ groups }) {
+  async function handleCreateUser(event) {
+    event.preventDefault();
+    const form = event.target;
+    const email = form.email.value;
+    const password = form.password.value;
+    const groups = form.groups.value.split(',').map(s => s.trim()).filter(Boolean);
+    await fetch('/api/admin/createUser', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, groups }),
+    });
+    form.reset();
+    alert('User created');
+  }
+
+  async function handleCreateGroup(event) {
+    event.preventDefault();
+    const form = event.target;
+    const name = form.name.value;
+    await fetch('/api/admin/createGroup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    form.reset();
+    alert('Group created');
+  }
+
   return (
-    <main>
-      <h1>Admin Panel</h1>
-      <p>Only for developers.</p>
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Admin Panel</h1>
+
+      <section className="mb-8">
+        <h2 className="font-semibold">Create User</h2>
+        <form onSubmit={handleCreateUser} className="flex flex-col gap-2 mt-2">
+          <input name="email" type="email" placeholder="Email" className="border p-2" required />
+          <input name="password" type="password" placeholder="Password" className="border p-2" required />
+          <input name="groups" placeholder="Groups (comma separated)" className="border p-2" />
+          <button type="submit" className="bg-blue-500 text-white p-2">Create</button>
+        </form>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="font-semibold">Create Group</h2>
+        <form onSubmit={handleCreateGroup} className="flex flex-col gap-2 mt-2">
+          <input name="name" placeholder="Group name" className="border p-2" required />
+          <button type="submit" className="bg-blue-500 text-white p-2">Create</button>
+        </form>
+        <p className="mt-2">Existing groups: {groups.join(', ')}</p>
+      </section>
     </main>
   );
 }

--- a/pages/api/admin/createGroup.js
+++ b/pages/api/admin/createGroup.js
@@ -1,0 +1,24 @@
+import { addGroup, getSession, getUsers } from '../../../lib/data.js';
+import { parse } from 'cookie';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.session;
+  const sessionUserId = getSession(token);
+  const currentUser = getUsers().find(u => u.id === sessionUserId);
+  if (!currentUser || !currentUser.groups.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const { name } = req.body || {};
+  if (!name) {
+    return res.status(400).json({ error: 'Missing name' });
+  }
+
+  addGroup(name);
+  res.status(200).json({ success: true });
+}

--- a/pages/api/admin/createUser.js
+++ b/pages/api/admin/createUser.js
@@ -1,0 +1,26 @@
+import { addUser, getSession, getUsers } from '../../../lib/data.js';
+import crypto from 'crypto';
+import { parse } from 'cookie';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.session;
+  const sessionUserId = getSession(token);
+  const currentUser = getUsers().find(u => u.id === sessionUserId);
+  if (!currentUser || !currentUser.groups.includes('admin')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const { email, password, groups } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+
+  const passwordHash = crypto.createHash('sha256').update(password).digest('hex');
+  addUser(email, passwordHash, Array.isArray(groups) ? groups : []);
+  res.status(200).json({ success: true });
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,28 @@
+import { findUserByEmail, createSession } from '../../lib/data.js';
+import crypto from 'crypto';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Missing credentials' });
+  }
+
+  const user = findUserByEmail(email);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid user' });
+  }
+
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  if (hash !== user.passwordHash) {
+    return res.status(401).json({ error: 'Invalid password' });
+  }
+
+  const token = crypto.randomBytes(16).toString('hex');
+  createSession(user.id, token);
+  res.setHeader('Set-Cookie', `session=${token}; Path=/; HttpOnly`);
+  res.status(200).json({ success: true });
+}

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,0 +1,12 @@
+import { deleteSession } from '../../lib/data.js';
+import { parse } from 'cookie';
+
+export default function handler(req, res) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.session;
+  if (token) {
+    deleteSession(token);
+    res.setHeader('Set-Cookie', 'session=; Path=/; Max-Age=0');
+  }
+  res.status(200).json({ success: true });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,33 @@
-export default function Home() {
+import { parse } from 'cookie';
+import { getSession, getUsers } from '../lib/data.js';
+import Link from 'next/link';
+
+export async function getServerSideProps({ req }) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  const token = cookies.session;
+  const userId = getSession(token);
+  const user = getUsers().find(u => u.id === userId) || null;
+  return { props: { user } };
+}
+
+export default function Home({ user }) {
+  async function handleLogout() {
+    await fetch('/api/logout');
+    location.reload();
+  }
   return (
-    <main>
-      <h1>Home Page</h1>
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Home Page</h1>
+      {!user && <Link href="/login" className="text-blue-600 underline">Login</Link>}
+      {user && (
+        <div className="flex flex-col gap-2">
+          <p>Logged in as {user.email}</p>
+          <button onClick={handleLogout} className="bg-gray-500 text-white p-2 w-24">Logout</button>
+          {user.groups.includes('admin') && (
+            <Link href="/AdminPanel" className="text-blue-600 underline">Admin Panel</Link>
+          )}
+        </div>
+      )}
     </main>
   );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,46 @@
+import { parse } from 'cookie';
+import { getSession } from '../lib/data.js';
+
+export async function getServerSideProps({ req }) {
+  const cookies = req.headers.cookie ? parse(req.headers.cookie) : {};
+  const token = cookies.session;
+  const userId = getSession(token);
+  if (userId) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}
+
+export default function Login() {
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+    const email = form.email.value;
+    const password = form.password.value;
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      location.href = '/';
+    } else {
+      alert('Login failed');
+    }
+  }
+  return (
+    <main className="p-4 flex flex-col items-center">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input name="email" type="email" placeholder="Email" className="border p-2" required />
+        <input name="password" type="password" placeholder="Password" className="border p-2" required />
+        <button type="submit" className="bg-blue-500 text-white p-2">Login</button>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace old admin panel gate with session-based email login
- add basic file-based user database and group support
- implement login & logout API routes
- add admin APIs to create users and groups
- create login page and update index page with session awareness
- seed example admin user in `data.json`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*