### PR TITLE
Fix Tailwind PostCSS plugin configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "autoprefixer": "latest",
     "postcss": "latest",
-    "tailwindcss": "latest"
+    "tailwindcss": "latest",
+    "@tailwindcss/postcss": "latest"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- update PostCSS configuration to use `@tailwindcss/postcss`
- include `@tailwindcss/postcss` in devDependencies

## Testing
- `npm run build` *(fails: `next` not found because dependencies aren't installed)*