### PR TITLE
Switch to bcrypt helpers for password operations

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,5 @@
 import pool from './db.js';
+import bcrypt from 'bcrypt';
 
 export async function getUsers() {
   const { rows } = await pool.query('SELECT id, email, password_hash AS "passwordHash", groups FROM users');
@@ -58,4 +59,12 @@ export async function deleteResetToken(token) {
 
 export async function updateUserPassword(email, passwordHash) {
   await pool.query('UPDATE users SET password_hash = $2 WHERE email = $1', [email, passwordHash]);
+}
+
+export async function hashPassword(password) {
+  return bcrypt.hash(password, 10);
+}
+
+export async function verifyPassword(password, passwordHash) {
+  return bcrypt.compare(password, passwordHash);
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pg": "^8.11.3",
     "cookie": "^0.5.0",
     "dotenv": "^16.3.1",
+    "bcrypt": "^5.1.1",
     "tailwindcss": "^3.4.1",
     "postcss": "^8.4.24",
     "autoprefixer": "^10.4.16"

--- a/pages/api/admin/createUser.js
+++ b/pages/api/admin/createUser.js
@@ -1,5 +1,9 @@
-import { createUser, getSession, getUsers } from '../../../lib/auth.js';
-import crypto from 'crypto';
+import {
+  createUser,
+  getSession,
+  getUsers,
+  hashPassword,
+} from '../../../lib/auth.js';
 import { parse } from 'cookie';
 
 export default async function handler(req, res) {
@@ -21,7 +25,7 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing fields' });
   }
 
-  const passwordHash = crypto.createHash('sha256').update(password).digest('hex');
+  const passwordHash = await hashPassword(password);
   await createUser(email, passwordHash, Array.isArray(groups) ? groups : []);
   res.status(200).json({ success: true });
 }

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,4 +1,4 @@
-import { findUserByEmail, createSession } from '../../lib/auth.js';
+import { findUserByEmail, createSession, verifyPassword } from '../../lib/auth.js';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
@@ -16,8 +16,8 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Invalid user' });
   }
 
-  const hash = crypto.createHash('sha256').update(password).digest('hex');
-  if (hash !== user.passwordHash) {
+  const valid = await verifyPassword(password, user.passwordHash);
+  if (!valid) {
     return res.status(401).json({ error: 'Invalid password' });
   }
 

--- a/pages/api/register.js
+++ b/pages/api/register.js
@@ -1,5 +1,4 @@
-import { createUser, findUserByEmail } from '../../lib/auth.js';
-import crypto from 'crypto';
+import { createUser, findUserByEmail, hashPassword } from '../../lib/auth.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -15,7 +14,7 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'User already exists' });
   }
 
-  const passwordHash = crypto.createHash('sha256').update(password).digest('hex');
+  const passwordHash = await hashPassword(password);
   await createUser(email, passwordHash, []);
 
   res.status(200).json({ success: true });

--- a/pages/api/reset-password.js
+++ b/pages/api/reset-password.js
@@ -2,8 +2,8 @@ import {
   getEmailByResetToken,
   deleteResetToken,
   updateUserPassword,
+  hashPassword,
 } from '../../lib/auth.js';
-import crypto from 'crypto';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Invalid token' });
   }
 
-  const passwordHash = crypto.createHash('sha256').update(password).digest('hex');
+  const passwordHash = await hashPassword(password);
   await updateUserPassword(email, passwordHash);
   await deleteResetToken(token);
   res.status(200).json({ success: true });


### PR DESCRIPTION
## Summary
- use helper functions for hashing and verifying passwords
- update registration, login, admin createUser, and password reset APIs to use helpers

## Testing
- `npm run lint` *(fails: next not found)*