### PR TITLE
Add simple dashboard and admin pages

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+const navItems = [
+  { label: 'Dashboard', href: '/' },
+  { label: 'Cost Calc', href: '/calculations/cost' },
+  { label: 'Price Lists', href: '/calculations/price' },
+  { label: 'Customers', href: '/customers' },
+  { label: 'Checklists', href: '/checklists' },
+  { label: 'Admin', href: '/admin' }
+];
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <header className="header">
+        <nav>
+          {navItems.map((item) => (
+            <Link key={item.href} href={item.href} className="nav-link">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </header>
+      <main className="container">{children}</main>
+    </>
+  );
+}

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+
+export default function AdminHome() {
+  return (
+    <Layout>
+      <h1>Administration</h1>
+      <div className="card-grid">
+        <div className="card">
+          <h3>User Management</h3>
+          <p>Create and edit users.</p>
+          <Link href="/admin/users">Open</Link>
+        </div>
+        <div className="card">
+          <h3>Settings</h3>
+          <p>System configuration.</p>
+          <Link href="/admin/settings">Open</Link>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/admin/settings.js
+++ b/pages/admin/settings.js
@@ -1,0 +1,10 @@
+import Layout from '../../components/Layout';
+
+export default function Settings() {
+  return (
+    <Layout>
+      <h1>Settings</h1>
+      <p>This page will contain system configuration in the future.</p>
+    </Layout>
+  );
+}

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -1,0 +1,32 @@
+import Layout from '../../components/Layout';
+
+const sampleUsers = [
+  { id: 1, name: 'Admin User', email: 'admin@example.com', role: 'Admin' },
+  { id: 2, name: 'Regular User', email: 'user@example.com', role: 'User' }
+];
+
+export default function UserManagement() {
+  return (
+    <Layout>
+      <h1>User Management</h1>
+      <table className="user-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sampleUsers.map((u) => (
+            <tr key={u.id}>
+              <td>{u.name}</td>
+              <td>{u.email}</td>
+              <td>{u.role}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Layout>
+  );
+}

--- a/pages/calculations/cost.js
+++ b/pages/calculations/cost.js
@@ -1,0 +1,10 @@
+import Layout from '../../components/Layout';
+
+export default function CostCalculations() {
+  return (
+    <Layout>
+      <h1>Cost Calculations</h1>
+      <p>Here you can build new cost distribution calculations.</p>
+    </Layout>
+  );
+}

--- a/pages/calculations/price.js
+++ b/pages/calculations/price.js
@@ -1,0 +1,10 @@
+import Layout from '../../components/Layout';
+
+export default function PriceLists() {
+  return (
+    <Layout>
+      <h1>Price Lists</h1>
+      <p>Generate price quotes for your customers.</p>
+    </Layout>
+  );
+}

--- a/pages/checklists/index.js
+++ b/pages/checklists/index.js
@@ -1,0 +1,10 @@
+import Layout from '../../components/Layout';
+
+export default function Checklists() {
+  return (
+    <Layout>
+      <h1>Checklists</h1>
+      <p>Work with your building checklists.</p>
+    </Layout>
+  );
+}

--- a/pages/customers/index.js
+++ b/pages/customers/index.js
@@ -1,0 +1,10 @@
+import Layout from '../../components/Layout';
+
+export default function Customers() {
+  return (
+    <Layout>
+      <h1>Customers</h1>
+      <p>Manage your customer database and assets.</p>
+    </Layout>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,37 @@
+import Link from 'next/link';
+import Layout from '../components/Layout';
+
 export default function Home() {
   return (
-    <main style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-      <h1>Under Construction</h1>
-    </main>
+    <Layout>
+      <h1>Dashboard</h1>
+      <div className="card-grid">
+        <div className="card">
+          <h3>Cost Calculations</h3>
+          <p>Create and manage cost distributions.</p>
+          <Link href="/calculations/cost">Open</Link>
+        </div>
+        <div className="card">
+          <h3>Price Lists</h3>
+          <p>Generate price quotes for customers.</p>
+          <Link href="/calculations/price">Open</Link>
+        </div>
+        <div className="card">
+          <h3>Customers</h3>
+          <p>View registered customers and assets.</p>
+          <Link href="/customers">Open</Link>
+        </div>
+        <div className="card">
+          <h3>Checklists</h3>
+          <p>Keep track of building checklists.</p>
+          <Link href="/checklists">Open</Link>
+        </div>
+        <div className="card">
+          <h3>Administration</h3>
+          <p>User management and system settings.</p>
+          <Link href="/admin">Open</Link>
+        </div>
+      </div>
+    </Layout>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,3 +2,46 @@ body {
   margin: 0;
   font-family: sans-serif;
 }
+
+.header {
+  background: #333;
+  color: #fff;
+  padding: 10px;
+}
+
+.nav-link {
+  color: #fff;
+  margin-right: 10px;
+  text-decoration: none;
+}
+
+.nav-link:hover {
+  text-decoration: underline;
+}
+
+.container {
+  padding: 20px;
+}
+
+.card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.user-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.user-table th,
+.user-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}


### PR DESCRIPTION
## Summary
- implement navigation layout
- create dashboard with navigation cards
- add admin pages with user table and settings placeholder
- add placeholder pages for cost, price, customers and checklists
- style basic layout and tables

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da00b0f1c832eab65cad0b94baf7f