### PR TITLE
Fix build by removing unused Tailwind plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
     autoprefixer: {},
   }
 };


### PR DESCRIPTION
## Summary
- remove `tailwindcss` plugin from PostCSS configuration

The GitHub Action failed because `tailwindcss` was not installed. Since the project does not use Tailwind, dropping the plugin lets Next.js build without requiring the package.

## Testing
- `npm run build` *(fails: `next` not found since dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683ead06c800832eb1de6b3ca3868dfb