### PR TITLE
Fix missing dependency for start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=18.x"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21"
+    "autoprefixer": "^10.4.21",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- add `cross-env` to dev dependencies

## Testing
- `npm start` *(fails: `next` not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_b_683ebafae184832ea694ec85b2f8f0e3