### PR TITLE
Move cross-env to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "cross-env PORT=3000 next start -p $PORT"
   },
   "dependencies": {
+    "cross-env": "^7.0.3",
     "next": "^14.2.29",
     "react": "18.2.0",
     "react-dom": "18.2.0"
@@ -16,7 +17,6 @@
     "node": ">=18.x"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21",
-    "cross-env": "^7.0.3"
+    "autoprefixer": "^10.4.21"
   }
 }


### PR DESCRIPTION
## Summary
- move `cross-env` from devDependencies to dependencies

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ef15b2858832e9f393c32e4c5bfc8