### PR TITLE
Configure build during deploy

### DIFF
--- a/.github/workflows/main_acronenergysystemtools.yml
+++ b/.github/workflows/main_acronenergysystemtools.yml
@@ -64,6 +64,18 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_6A254CEF1C1D4AD69608514CD9E9EE9F }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_3B09DB5238FC48B585E13BB28E40E897 }}
 
+      - name: Configure build during deployment
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: 'acronenergysystemtools'
+          app-settings-json: |
+            [
+              {
+                "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                "value": "true"
+              }
+            ]
+
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
## Summary
- set `SCM_DO_BUILD_DURING_DEPLOYMENT=true` before deployment in main workflow

## Testing
- `npm run test` *(fails: Missing script)*
- `npm install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_b_6841547aa0bc832e9b4d9117bf128a9a