### PR TITLE
Add basic auth context and integrate login

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useAuth } from '../contexts/AuthContext';
 
 const navItems = [
   { label: 'Dashboard', href: '/' },
@@ -10,15 +11,23 @@ const navItems = [
 ];
 
 export default function Layout({ children }) {
+  const { isAuthenticated, user, logout } = useAuth();
   return (
     <>
       <header className="header">
-        <nav>
+        <nav className="nav">
           {navItems.map((item) => (
             <Link key={item.href} href={item.href} className="nav-link">
               {item.label}
             </Link>
           ))}
+          {isAuthenticated ? (
+            <button onClick={logout} className="nav-link button-logout">
+              Sign Out ({user.name})
+            </button>
+          ) : (
+            <Link href="/login" className="nav-link">Login</Link>
+          )}
         </nav>
       </header>
       <main className="container">{children}</main>

--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -1,0 +1,78 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const MOCK_USERS = [
+  {
+    id: '1',
+    email: 'admin@example.com',
+    password: 'admin123',
+    name: 'Admin User',
+    isAdmin: true,
+  },
+  {
+    id: '2',
+    email: 'user@example.com',
+    password: 'user123',
+    name: 'Regular User',
+    isAdmin: false,
+  },
+];
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('user');
+      if (stored) setUser(JSON.parse(stored));
+    }
+    setLoading(false);
+  }, []);
+
+  const login = async (email, password) => {
+    const found = MOCK_USERS.find(
+      (u) => u.email === email && u.password === password
+    );
+    if (found) {
+      const { password: _p, ...withoutPw } = found;
+      setUser(withoutPw);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('user', JSON.stringify(withoutPw));
+      }
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    setUser(null);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('user');
+    }
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        loading,
+        login,
+        logout,
+        isAuthenticated: !!user,
+        isAdmin: user?.isAdmin || false,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,10 @@
 import '../styles/globals.css'
+import { AuthProvider } from '../contexts/AuthContext'
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  )
 }

--- a/pages/admin/settings.js
+++ b/pages/admin/settings.js
@@ -1,10 +1,40 @@
+import { useState } from 'react';
 import Layout from '../../components/Layout';
 
 export default function Settings() {
+  const [title, setTitle] = useState('Calculation Portal');
+  const [enableReg, setEnableReg] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert('Demo save not implemented');
+  };
+
   return (
     <Layout>
-      <h1>Settings</h1>
-      <p>This page will contain system configuration in the future.</p>
+      <h1>System Settings</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="title">Portal Title</label>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div className="form-group">
+          <label>
+            <input
+              type="checkbox"
+              checked={enableReg}
+              onChange={(e) => setEnableReg(e.target.checked)}
+            />
+            Enable User Registration
+          </label>
+        </div>
+        <button type="submit" className="button">Save</button>
+      </form>
     </Layout>
   );
 }

--- a/pages/calculations/price.js
+++ b/pages/calculations/price.js
@@ -1,10 +1,50 @@
+import { useState } from 'react';
 import Layout from '../../components/Layout';
 
+const defaultItems = [
+  { id: '1', description: 'Grunpakke AES (pr bygg)', pricePerYear: 2880, qty: 0 },
+  { id: '2', description: 'Ekstra Ethub målepunkt', pricePerYear: 1440, qty: 0 },
+  { id: '3', description: 'Gateway for sensorer', pricePerYear: 720, qty: 0 },
+];
+
 export default function PriceLists() {
+  const [items, setItems] = useState(defaultItems);
+
+  const updateQty = (id, qty) => {
+    setItems(items.map((it) => (it.id === id ? { ...it, qty } : it)));
+  };
+
+  const total = items.reduce((sum, it) => sum + it.pricePerYear * it.qty, 0);
+
   return (
     <Layout>
-      <h1>Price Lists</h1>
-      <p>Generate price quotes for your customers.</p>
+      <h1>Price List</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th>Price / year</th>
+            <th>Qty</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it) => (
+            <tr key={it.id}>
+              <td>{it.description}</td>
+              <td>{it.pricePerYear} kr</td>
+              <td>
+                <input
+                  type="number"
+                  value={it.qty}
+                  onChange={(e) => updateQty(it.id, parseInt(e.target.value) || 0)}
+                  style={{ width: '60px' }}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>Total: {total} kr / year</p>
     </Layout>
   );
 }

--- a/pages/checklists/index.js
+++ b/pages/checklists/index.js
@@ -1,10 +1,53 @@
+import { useState } from 'react';
 import Layout from '../../components/Layout';
 
+const initialItems = [
+  { id: 1, text: 'Inspect ventilation system', done: false },
+  { id: 2, text: 'Check heating controls', done: false },
+];
+
 export default function Checklists() {
+  const [items, setItems] = useState(initialItems);
+  const [task, setTask] = useState('');
+
+  const addItem = (e) => {
+    e.preventDefault();
+    if (!task.trim()) return;
+    setItems([...items, { id: Date.now(), text: task.trim(), done: false }]);
+    setTask('');
+  };
+
+  const toggleItem = (id) => {
+    setItems(items.map((it) => (it.id === id ? { ...it, done: !it.done } : it)));
+  };
+
   return (
     <Layout>
       <h1>Checklists</h1>
-      <p>Work with your building checklists.</p>
+      <form onSubmit={addItem} className="form-group">
+        <label htmlFor="task">New Task</label>
+        <input
+          id="task"
+          type="text"
+          value={task}
+          onChange={(e) => setTask(e.target.value)}
+        />
+        <button type="submit" className="button">Add</button>
+      </form>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            <label>
+              <input
+                type="checkbox"
+                checked={item.done}
+                onChange={() => toggleItem(item.id)}
+              />
+              {item.text}
+            </label>
+          </li>
+        ))}
+      </ul>
     </Layout>
   );
 }

--- a/pages/customers/index.js
+++ b/pages/customers/index.js
@@ -1,10 +1,52 @@
+import { useState } from 'react';
 import Layout from '../../components/Layout';
 
+const sampleCustomers = [
+  {
+    id: 1,
+    name: 'Acme Corp',
+    org: '123456789',
+    contact: { name: 'John Doe', email: 'john@example.com' },
+    assets: 3,
+  },
+  {
+    id: 2,
+    name: 'Globex LLC',
+    org: '987654321',
+    contact: { name: 'Jane Smith', email: 'jane@example.com' },
+    assets: 1,
+  },
+];
+
 export default function Customers() {
+  const [customers] = useState(sampleCustomers);
+
   return (
     <Layout>
       <h1>Customers</h1>
-      <p>Manage your customer database and assets.</p>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Org Number</th>
+            <th>Contact</th>
+            <th>Assets</th>
+          </tr>
+        </thead>
+        <tbody>
+          {customers.map((c) => (
+            <tr key={c.id}>
+              <td>{c.name}</td>
+              <td>{c.org}</td>
+              <td>
+                <div>{c.contact.name}</div>
+                <div className="small">{c.contact.email}</div>
+              </td>
+              <td>{c.assets}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </Layout>
   );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '../contexts/AuthContext';
+import '../styles/login.css';
+
+export default function Login() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Please fill in both fields');
+      return;
+    }
+    const success = await login(email, password);
+    if (success) {
+      setError('');
+      router.push('/');
+    } else {
+      setError('Invalid email or password');
+    }
+  };
+
+  return (
+    <div className="login-container">
+      <div className="login-card">
+        <h1>Acron Energy Tools</h1>
+        <h2>Welcome Back</h2>
+        <p className="description">Sign in to your account to continue</p>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              placeholder="your.email@company.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          {error && <p className="error">{error}</p>}
+          <button type="submit" className="button">Sign In</button>
+        </form>
+        <p className="footer">Demo credentials: admin@example.com / admin123</p>
+      </div>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,6 +15,19 @@ body {
   text-decoration: none;
 }
 
+.nav {
+  display: flex;
+  align-items: center;
+}
+
+.button-logout {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  margin-left: auto;
+}
+
 .nav-link:hover {
   text-decoration: underline;
 }
@@ -44,4 +57,40 @@ body {
 .user-table td {
   border: 1px solid #ddd;
   padding: 8px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.form-group {
+  margin-bottom: 12px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.button {
+  padding: 8px 16px;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }

--- a/styles/login.css
+++ b/styles/login.css
@@ -1,0 +1,73 @@
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f3f5;
+  padding: 20px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 400px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  padding: 24px;
+  text-align: center;
+}
+
+.login-card h1 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 24px;
+}
+
+.login-card h2 {
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-size: 20px;
+}
+
+.login-card .description {
+  margin-bottom: 16px;
+  color: #555;
+}
+
+.form-group {
+  text-align: left;
+  margin-bottom: 12px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.error {
+  color: #d4183d;
+  margin: 8px 0;
+}
+
+.button {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.footer {
+  margin-top: 12px;
+  font-size: 0.9em;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- implement minimal AuthProvider with demo users
- wrap application with provider
- update Layout to display login link and sign-out
- enhance login page to use auth context
- tweak global styles for nav

## Testing
- `npm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68415df5d24c832e96f57024cba25d3c