### PR TITLE
Fix string escaping in cost calculation

### DIFF
--- a/pages/calculations/cost.js
+++ b/pages/calculations/cost.js
@@ -203,26 +203,26 @@ export default function CostCalculations() {
       const card = document.createElement('div');
       card.className = 'relative border rounded p-3 bg-gray-50';
       card.innerHTML = \`
-        <button data-id="\${id}" class="absolute top-1 right-1 text-gray-500 hover:text-gray-700">&times;</button>
+        <button data-id="\\${id}" class="absolute top-1 right-1 text-gray-500 hover:text-gray-700">&times;</button>
         <label class="block text-sm mb-1">Navn</label>
-        <input type="text" id="name_\${id}" value="\${data.name || ''}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
+        <input type="text" id="name_\\${id}" value="\\${data.name || ''}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
         <label class="block text-sm mb-1">Areal (m²)</label>
-        <input type="number" id="area_\${id}" value="\${data.area || 100}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
+        <input type="number" id="area_\\${id}" value="\\${data.area || 100}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
         <label class="block text-sm mb-1">El-forbruk (kWh)</label>
-        <input type="number" id="el_\${id}" value="\${data.el || 1000}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
+        <input type="number" id="el_\\${id}" value="\\${data.el || 1000}" class="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none" />
         <label class="block text-sm mb-1">Rabatt sol (%)</label>
-        <input type="number" id="discount_\${id}" value="0" class="w-full p-1 border rounded mb-2 focus:ring-blue-300 focus:outline-none text-sm" />
+        <input type="number" id="discount_\\${id}" value="0" class="w-full p-1 border rounded mb-2 focus:ring-blue-300 focus:outline-none text-sm" />
         <div class="grid grid-cols-2 gap-2 mt-2">
           <div>
             <label class="block text-sm">Fordel el</label>
-            <select id="dist_e_\${id}" class="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs">
+            <select id="dist_e_\\${id}" class="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs">
               <option value="consumption">Forbruk</option>
               <option value="area">Areal</option>
             </select>
           </div>
           <div>
             <label class="block text-sm">Fordel sol</label>
-            <select id="dist_p_\${id}" class="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs">
+            <select id="dist_p_\\${id}" class="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs">
               <option value="consumption">Forbruk</option>
               <option value="area">Areal</option>
             </select>
@@ -245,6 +245,8 @@ export default function CostCalculations() {
       const PP = parseFloat(document.getElementById('price_production').value);
       const PT = parseFloat(document.getElementById('price_thermal').value);
       const PW = parseFloat(document.getElementById('price_water').value);
+      const TT = parseFloat(document.getElementById('total_thermal').value);
+      const TW = parseFloat(document.getElementById('total_water').value);
 
       // Egenforbruk bygget
       const selfConsumed = PE - EE;
@@ -257,12 +259,12 @@ export default function CostCalculations() {
 
       document.querySelectorAll('#tenants > div').forEach(card => {
         const id = card.querySelector('button').dataset.id;
-        const name = document.getElementById(`name_\${id}`).value;
-        const area = parseFloat(document.getElementById(`area_\${id}`).value);
-        const el = parseFloat(document.getElementById(`el_\${id}`).value);
-        const discount = parseFloat(document.getElementById(`discount_\${id}`).value) / 100;
-        const distE = document.getElementById(`dist_e_\${id}`).value;
-        const distP = document.getElementById(`dist_p_\${id}`).value;
+        const name = document.getElementById(`name_\\${id}`).value;
+        const area = parseFloat(document.getElementById(`area_\\${id}`).value);
+        const el = parseFloat(document.getElementById(`el_\\${id}`).value);
+        const discount = parseFloat(document.getElementById(`discount_\\${id}`).value) / 100;
+        const distE = document.getElementById(`dist_e_\\${id}`).value;
+        const distP = document.getElementById(`dist_p_\\${id}`).value;
 
         const totalArea = parseFloat(document.getElementById('total_area').value);
         const areaPct = totalArea > 0 ? ((area / totalArea) * 100).toFixed(1) : '0.0';
@@ -286,11 +288,11 @@ export default function CostCalculations() {
         const div = document.createElement('div');
         div.className = 'p-3 bg-white rounded shadow';
         div.innerHTML = \`
-          <h3 class="font-semibold mb-1">\${name}</h3>
-          <p class="text-sm">Arealandel: \${areaPct} %</p>
-          <p class="text-sm">El-kostnad: \${elCost.toFixed(1)} kr</p>
-          <p class="text-sm">Produksjonsandel (rabatt \${(discount * 100).toFixed(0)}%): -\${exportShare.toFixed(1)} kr</p>
-          <p class="font-semibold text-right">Totalt: \${total.toFixed(1)} kr</p>
+          <h3 class="font-semibold mb-1">\\${name}</h3>
+          <p class="text-sm">Arealandel: \\${areaPct} %</p>
+          <p class="text-sm">El-kostnad: \\${elCost.toFixed(1)} kr</p>
+          <p class="text-sm">Produksjonsandel (rabatt \\${(discount * 100).toFixed(0)}%): -\\${exportShare.toFixed(1)} kr</p>
+          <p class="font-semibold text-right">Totalt: \\${total.toFixed(1)} kr</p>
         \`;
         cardsDiv.appendChild(div);
       });


### PR DESCRIPTION
## Summary
- fix escaping inside embedded script
- add missing total water & thermal variables

## Testing
- `node --check pages/calculations/cost.js`

------
https://chatgpt.com/codex/tasks/task_b_68429f869284832eabef95d2de648d89