### PR TITLE
Fix escaped element IDs

### DIFF
--- a/pages/calculations/cost.js
+++ b/pages/calculations/cost.js
@@ -259,10 +259,11 @@ export default function CostCalculations() {
 
       document.querySelectorAll('#tenants > div').forEach(card => {
         const id = card.querySelector('button').dataset.id;
-        const name = document.getElementById(`name_${id}`).value;
-        const area = parseFloat(document.getElementById(`area_${id}`).value);
-        const el = parseFloat(document.getElementById(`el_${id}`).value);
-        const discount = parseFloat(document.getElementById(`discount_${id}`).value) / 100;
+        const name = document.getElementById('name_' + id).value;
+        const area = parseFloat(document.getElementById('area_' + id).value);
+        const el = parseFloat(document.getElementById('el_' + id).value);
+        const discount =
+          parseFloat(document.getElementById('discount_' + id).value) / 100;
         const distE = document.getElementById(`dist_e_\${id}`).value;
         const distP = document.getElementById(`dist_p_\${id}`).value;
 


### PR DESCRIPTION
## Summary
- fix inline script selectors for tenant card values so template literal output is valid

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c7526150832ebd787e4e98deab9c