### PR TITLE
Fix Next.js build errors

### DIFF
--- a/pages/calculations/cost.tsx
+++ b/pages/calculations/cost.tsx
@@ -239,10 +239,7 @@ export default function CostCalculations() {
           <button
             type="button"
             onClick={addTenant}
-          <div id="tenants" className="space-y-3" />
-          <button
             id="addTenant"
-
             className="mt-2 bg-blue-500 hover:bg-blue-600 text-white text-sm py-1 px-3 rounded transition"
           >
             + Legg til leietaker
@@ -330,7 +327,6 @@ export default function CostCalculations() {
             <div>
               <label className="block mb-1 text-sm">Spotpris forbruk (kr/kWh)</label>
               <input
-s
                 type="number"
                 step="0.01"
                 value={priceConsumption}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "Figma design"
   ]
 }


### PR DESCRIPTION
## Summary
- exclude `Figma design` mockups from tsconfig
- correct malformed JSX in cost calculation page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842de38d59c832e99e7dd07b3a79efe