### PR TITLE
Improve state typings

### DIFF
--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -1,13 +1,13 @@
-import { FormEvent, ChangeEvent, useState } from 'react';
-import Layout from '../../components/Layout';
+import { FormEvent, ChangeEvent, useState } from "react";
+import Layout from "../../components/Layout";
 
 export default function Settings() {
-  const [title, setTitle] = useState('Calculation Portal');
-  const [enableReg, setEnableReg] = useState(false);
+  const [title, setTitle] = useState<string>("Calculation Portal");
+  const [enableReg, setEnableReg] = useState<boolean>(false);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    alert('Demo save not implemented');
+    alert("Demo save not implemented");
   };
 
   return (
@@ -37,7 +37,9 @@ export default function Settings() {
             Enable User Registration
           </label>
         </div>
-        <button type="submit" className="button">Save</button>
+        <button type="submit" className="button">
+          Save
+        </button>
       </form>
     </Layout>
   );

--- a/pages/calculations/cost.tsx
+++ b/pages/calculations/cost.tsx
@@ -1,7 +1,6 @@
-
-import React, { useState } from 'react';
-import Head from 'next/head';
-import Layout from '../../components/Layout';
+import React, { useState } from "react";
+import Head from "next/head";
+import Layout from "../../components/Layout";
 
 interface Tenant {
   id: number;
@@ -9,8 +8,24 @@ interface Tenant {
   area: number;
   el: number;
   discount: number;
-  distE: 'consumption' | 'area';
-  distP: 'consumption' | 'area';
+  distE: "consumption" | "area";
+  distP: "consumption" | "area";
+}
+
+interface TenantResult {
+  id: number;
+  name: string;
+  areaPct: string;
+  elCost: number;
+  exportShare: number;
+  discount: number;
+  total: number;
+}
+
+interface CalculationResults {
+  selfConsumed: string;
+  selfPercent: string;
+  tenantResults: TenantResult[];
 }
 
 interface TenantCardProps {
@@ -23,7 +38,7 @@ function TenantCard({ tenant, onChange, onRemove }: TenantCardProps) {
     (field: keyof Tenant) =>
     (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
       const value =
-        field === 'name' ? e.target.value : parseFloat(e.target.value) || 0;
+        field === "name" ? e.target.value : parseFloat(e.target.value) || 0;
       onChange({ ...tenant, [field]: value });
     };
 
@@ -40,28 +55,28 @@ function TenantCard({ tenant, onChange, onRemove }: TenantCardProps) {
       <input
         type="text"
         value={tenant.name}
-        onChange={handle('name')}
+        onChange={handle("name")}
         className="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none"
       />
       <label className="block text-sm mb-1">Areal (m²)</label>
       <input
         type="number"
         value={tenant.area}
-        onChange={handle('area')}
+        onChange={handle("area")}
         className="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none"
       />
       <label className="block text-sm mb-1">El-forbruk (kWh)</label>
       <input
         type="number"
         value={tenant.el}
-        onChange={handle('el')}
+        onChange={handle("el")}
         className="w-full p-1 border rounded mb-1 focus:ring-blue-300 focus:outline-none"
       />
       <label className="block text-sm mb-1">Rabatt sol (%)</label>
       <input
         type="number"
         value={tenant.discount}
-        onChange={handle('discount')}
+        onChange={handle("discount")}
         className="w-full p-1 border rounded mb-2 focus:ring-blue-300 focus:outline-none text-sm"
       />
       <div className="grid grid-cols-2 gap-2 mt-2">
@@ -69,7 +84,7 @@ function TenantCard({ tenant, onChange, onRemove }: TenantCardProps) {
           <label className="block text-sm">Fordel el</label>
           <select
             value={tenant.distE}
-            onChange={handle('distE')}
+            onChange={handle("distE")}
             className="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs"
           >
             <option value="consumption">Forbruk</option>
@@ -80,7 +95,7 @@ function TenantCard({ tenant, onChange, onRemove }: TenantCardProps) {
           <label className="block text-sm">Fordel sol</label>
           <select
             value={tenant.distP}
-            onChange={handle('distP')}
+            onChange={handle("distP")}
             className="w-full p-1 border rounded focus:ring-blue-300 focus:outline-none text-xs"
           >
             <option value="consumption">Forbruk</option>
@@ -93,55 +108,55 @@ function TenantCard({ tenant, onChange, onRemove }: TenantCardProps) {
 }
 
 export default function CostCalculations() {
-  const [totalArea, setTotalArea] = useState(1000);
-  const [commonArea, setCommonArea] = useState(200);
-  const [totalElectric, setTotalElectric] = useState(12000);
-  const [totalThermal, setTotalThermal] = useState(8000);
-  const [totalWater, setTotalWater] = useState(120);
-  const [prodEnergy, setProdEnergy] = useState(4000);
-  const [exportEnergy, setExportEnergy] = useState(2500);
-  const [priceConsumption, setPriceConsumption] = useState(0.64);
-  const [priceProduction, setPriceProduction] = useState(0.64);
-  const [gridFixed, setGridFixed] = useState(300);
-  const [gridEnergy, setGridEnergy] = useState(0.3);
-  const [priceThermal, setPriceThermal] = useState(0.7);
-  const [priceWater, setPriceWater] = useState(50);
+  const [totalArea, setTotalArea] = useState<number>(1000);
+  const [commonArea, setCommonArea] = useState<number>(200);
+  const [totalElectric, setTotalElectric] = useState<number>(12000);
+  const [totalThermal, setTotalThermal] = useState<number>(8000);
+  const [totalWater, setTotalWater] = useState<number>(120);
+  const [prodEnergy, setProdEnergy] = useState<number>(4000);
+  const [exportEnergy, setExportEnergy] = useState<number>(2500);
+  const [priceConsumption, setPriceConsumption] = useState<number>(0.64);
+  const [priceProduction, setPriceProduction] = useState<number>(0.64);
+  const [gridFixed, setGridFixed] = useState<number>(300);
+  const [gridEnergy, setGridEnergy] = useState<number>(0.3);
+  const [priceThermal, setPriceThermal] = useState<number>(0.7);
+  const [priceWater, setPriceWater] = useState<number>(50);
 
-  const [nextId, setNextId] = useState(2);
+  const [nextId, setNextId] = useState<number>(2);
   const [tenants, setTenants] = useState<Tenant[]>([
     {
       id: 0,
-      name: 'Butikk A',
+      name: "Butikk A",
       area: 300,
       el: 600,
       discount: 0,
-      distE: 'consumption',
-      distP: 'consumption',
+      distE: "consumption",
+      distP: "consumption",
     },
     {
       id: 1,
-      name: 'Kontor B',
+      name: "Kontor B",
       area: 500,
       el: 200,
       discount: 0,
-      distE: 'consumption',
-      distP: 'consumption',
+      distE: "consumption",
+      distP: "consumption",
     },
   ]);
 
-  const [results, setResults] = useState(null);
+  const [results, setResults] = useState<CalculationResults | null>(null);
 
   const addTenant = () => {
     setTenants([
       ...tenants,
       {
         id: nextId,
-        name: '',
+        name: "",
         area: 100,
         el: 1000,
         discount: 0,
-        distE: 'consumption',
-        distP: 'consumption',
+        distE: "consumption",
+        distP: "consumption",
       },
     ]);
     setNextId(nextId + 1);
@@ -167,19 +182,20 @@ export default function CostCalculations() {
     const TW = totalWater;
 
     const selfConsumed = PE - EE;
-    const selfPercent = PE > 0 ? ((selfConsumed / PE) * 100).toFixed(1) : '0.0';
+    const selfPercent = PE > 0 ? ((selfConsumed / PE) * 100).toFixed(1) : "0.0";
 
     const tenantResults = tenants.map((t) => {
-      const areaPct = totalArea > 0 ? ((t.area / totalArea) * 100).toFixed(1) : '0.0';
+      const areaPct =
+        totalArea > 0 ? ((t.area / totalArea) * 100).toFixed(1) : "0.0";
       const elCost =
-        t.distE === 'consumption'
+        t.distE === "consumption"
           ? (t.el / TE) * PC * TE
           : (t.area / totalArea) * PC * TE;
       const thCost = PT * TT;
       const wCost = PW * TW;
       const exportIncome = EE * PP;
       const baseShare =
-        t.distP === 'consumption'
+        t.distP === "consumption"
           ? (t.el / TE) * exportIncome
           : (t.area / totalArea) * exportIncome;
       const exportShare = baseShare * (1 - t.discount / 100);
@@ -195,9 +211,12 @@ export default function CostCalculations() {
       };
     });
 
-    setResults({ selfConsumed: selfConsumed.toFixed(1), selfPercent, tenantResults });
+    setResults({
+      selfConsumed: selfConsumed.toFixed(1),
+      selfPercent,
+      tenantResults,
+    });
   };
-
 
   return (
     <Layout>
@@ -210,20 +229,24 @@ export default function CostCalculations() {
         />
       </Head>
       <div className="max-w-4xl mx-auto p-6 mt-10 bg-white shadow-lg rounded-lg">
-        <h1 className="text-2xl font-semibold text-center mb-6">Kostnads- og Inntektsfordeling</h1>
+        <h1 className="text-2xl font-semibold text-center mb-6">
+          Kostnads- og Inntektsfordeling
+        </h1>
 
         {/* 1. Byggstruktur */}
         <section className="mb-6">
           <h2 className="font-medium mb-3 border-b pb-1">1. Byggstruktur</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block mb-1 text-sm">Totalt byggareal (m²)</label>
+              <label className="block mb-1 text-sm">
+                Totalt byggareal (m²)
+              </label>
               <input
-
                 type="number"
                 value={totalArea}
-                onChange={(e) => setTotalArea(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setTotalArea(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
@@ -232,8 +255,9 @@ export default function CostCalculations() {
               <input
                 type="number"
                 value={commonArea}
-                onChange={(e) => setCommonArea(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setCommonArea(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
@@ -266,72 +290,80 @@ export default function CostCalculations() {
 
         {/* 3. Forbruk & produksjon */}
         <section className="mb-6">
-          <h2 className="font-medium mb-3 border-b pb-1">3. Forbruk & Produksjon (Bygget totalt)</h2>
+          <h2 className="font-medium mb-3 border-b pb-1">
+            3. Forbruk & Produksjon (Bygget totalt)
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
               <label className="block mb-1 text-sm">El-forbruk (kWh/mnd)</label>
               <input
-
                 type="number"
                 value={totalElectric}
-                onChange={(e) => setTotalElectric(parseFloat(e.target.value) || 0)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setTotalElectric(parseFloat(e.target.value) || 0)
+                }
                 id="total_electric"
                 type="number"
                 defaultValue="12000"
-
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Termisk forbruk (kWh/mnd)</label>
+              <label className="block mb-1 text-sm">
+                Termisk forbruk (kWh/mnd)
+              </label>
               <input
-
                 type="number"
                 value={totalThermal}
-                onChange={(e) => setTotalThermal(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setTotalThermal(parseFloat(e.target.value) || 0)
+                }
                 id="total_thermal"
                 type="number"
                 defaultValue="8000"
-
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
               <label className="block mb-1 text-sm">Vannforbruk (m³/mnd)</label>
               <input
-
                 type="number"
                 value={totalWater}
-                onChange={(e) => setTotalWater(parseFloat(e.target.value) || 0)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setTotalWater(parseFloat(e.target.value) || 0)
+                }
                 id="total_water"
                 type="number"
                 defaultValue="120"
-
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Produsert solenergi (kWh/mnd)</label>
+              <label className="block mb-1 text-sm">
+                Produsert solenergi (kWh/mnd)
+              </label>
               <input
-
                 type="number"
                 value={prodEnergy}
-                onChange={(e) => setProdEnergy(parseFloat(e.target.value) || 0)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setProdEnergy(parseFloat(e.target.value) || 0)
+                }
                 id="prod_energy"
                 type="number"
                 defaultValue="4000"
-
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Eksportert energi (kWh/mnd)</label>
+              <label className="block mb-1 text-sm">
+                Eksportert energi (kWh/mnd)
+              </label>
               <input
-
                 type="number"
                 value={exportEnergy}
-                onChange={(e) => setExportEnergy(parseFloat(e.target.value) || 0)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setExportEnergy(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
@@ -343,71 +375,82 @@ export default function CostCalculations() {
           <h2 className="font-medium mb-3 border-b pb-1">4. Prisstruktur</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block mb-1 text-sm">Spotpris forbruk (kr/kWh)</label>
+              <label className="block mb-1 text-sm">
+                Spotpris forbruk (kr/kWh)
+              </label>
               <input
                 type="number"
                 step="0.01"
                 value={priceConsumption}
-                onChange={(e) => setPriceConsumption(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setPriceConsumption(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Spotpris produksjon (kr/kWh)</label>
+              <label className="block mb-1 text-sm">
+                Spotpris produksjon (kr/kWh)
+              </label>
               <input
-
                 type="number"
                 step="0.01"
                 value={priceProduction}
-                onChange={(e) => setPriceProduction(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setPriceProduction(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Nettleie fastledd (kr/mnd)</label>
+              <label className="block mb-1 text-sm">
+                Nettleie fastledd (kr/mnd)
+              </label>
               <input
-
                 type="number"
                 value={gridFixed}
-                onChange={(e) => setGridFixed(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setGridFixed(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Nettleie energiledd (kr/kWh)</label>
+              <label className="block mb-1 text-sm">
+                Nettleie energiledd (kr/kWh)
+              </label>
               <input
-
                 type="number"
                 step="0.01"
                 value={gridEnergy}
-                onChange={(e) => setGridEnergy(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setGridEnergy(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
-              <label className="block mb-1 text-sm">Pris termisk energi (kr/kWh)</label>
+              <label className="block mb-1 text-sm">
+                Pris termisk energi (kr/kWh)
+              </label>
               <input
-
                 type="number"
                 step="0.01"
                 value={priceThermal}
-                onChange={(e) => setPriceThermal(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setPriceThermal(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
             <div>
               <label className="block mb-1 text-sm">Pris vann (kr/m³)</label>
               <input
-
                 type="number"
                 value={priceWater}
-                onChange={(e) => setPriceWater(parseFloat(e.target.value) || 0)}
-
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setPriceWater(parseFloat(e.target.value) || 0)
+                }
                 className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
               />
             </div>
@@ -417,10 +460,8 @@ export default function CostCalculations() {
         {/* Beregn knapp */}
         <div className="text-center mb-6">
           <button
-
             type="button"
             onClick={calculate}
-
             className="bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-6 rounded transition"
           >
             Beregn kostnader
@@ -434,7 +475,8 @@ export default function CostCalculations() {
             <h2 className="font-medium mb-3 border-b pb-1">5. Resultater</h2>
             <div className="mb-4 p-3 bg-white rounded shadow">
               <p className="text-sm">
-                <strong>Egenforbruk bygget:</strong> {results.selfConsumed} kWh ({results.selfPercent} %)
+                <strong>Egenforbruk bygget:</strong> {results.selfConsumed} kWh
+                ({results.selfPercent} %)
               </p>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -442,16 +484,22 @@ export default function CostCalculations() {
                 <div key={r.id} className="p-3 bg-white rounded shadow">
                   <h3 className="font-semibold mb-1">{r.name}</h3>
                   <p className="text-sm">Arealandel: {r.areaPct} %</p>
-                  <p className="text-sm">El-kostnad: {r.elCost.toFixed(1)} kr</p>
-                  <p className="text-sm">Produksjonsandel (rabatt {r.discount}%): -{r.exportShare.toFixed(1)} kr</p>
-                  <p className="font-semibold text-right">Totalt: {r.total.toFixed(1)} kr</p>
+                  <p className="text-sm">
+                    El-kostnad: {r.elCost.toFixed(1)} kr
+                  </p>
+                  <p className="text-sm">
+                    Produksjonsandel (rabatt {r.discount}%): -
+                    {r.exportShare.toFixed(1)} kr
+                  </p>
+                  <p className="font-semibold text-right">
+                    Totalt: {r.total.toFixed(1)} kr
+                  </p>
                 </div>
               ))}
             </div>
           </section>
         )}
       </div>
-
     </Layout>
   );
 }

--- a/pages/calculations/price.tsx
+++ b/pages/calculations/price.tsx
@@ -1,14 +1,31 @@
-import { ChangeEvent, useState } from 'react';
-import Layout from '../../components/Layout';
+import { ChangeEvent, useState } from "react";
+import Layout from "../../components/Layout";
 
-const defaultItems = [
-  { id: '1', description: 'Grunpakke AES (pr bygg)', pricePerYear: 2880, qty: 0 },
-  { id: '2', description: 'Ekstra Ethub målepunkt', pricePerYear: 1440, qty: 0 },
-  { id: '3', description: 'Gateway for sensorer', pricePerYear: 720, qty: 0 },
+interface PriceItem {
+  id: string;
+  description: string;
+  pricePerYear: number;
+  qty: number;
+}
+
+const defaultItems: PriceItem[] = [
+  {
+    id: "1",
+    description: "Grunpakke AES (pr bygg)",
+    pricePerYear: 2880,
+    qty: 0,
+  },
+  {
+    id: "2",
+    description: "Ekstra Ethub målepunkt",
+    pricePerYear: 1440,
+    qty: 0,
+  },
+  { id: "3", description: "Gateway for sensorer", pricePerYear: 720, qty: 0 },
 ];
 
 export default function PriceLists() {
-  const [items, setItems] = useState(defaultItems);
+  const [items, setItems] = useState<PriceItem[]>(defaultItems);
 
   const updateQty = (id: string, qty: number) => {
     setItems(items.map((it) => (it.id === id ? { ...it, qty } : it)));
@@ -39,7 +56,7 @@ export default function PriceLists() {
                   onChange={(e: ChangeEvent<HTMLInputElement>) =>
                     updateQty(it.id, parseInt(e.target.value) || 0)
                   }
-                  style={{ width: '60px' }}
+                  style={{ width: "60px" }}
                 />
               </td>
             </tr>

--- a/pages/checklists/index.tsx
+++ b/pages/checklists/index.tsx
@@ -1,24 +1,32 @@
-import { FormEvent, ChangeEvent, useState } from 'react';
-import Layout from '../../components/Layout';
+import { FormEvent, ChangeEvent, useState } from "react";
+import Layout from "../../components/Layout";
 
-const initialItems = [
-  { id: 1, text: 'Inspect ventilation system', done: false },
-  { id: 2, text: 'Check heating controls', done: false },
+interface ChecklistItem {
+  id: number;
+  text: string;
+  done: boolean;
+}
+
+const initialItems: ChecklistItem[] = [
+  { id: 1, text: "Inspect ventilation system", done: false },
+  { id: 2, text: "Check heating controls", done: false },
 ];
 
 export default function Checklists() {
-  const [items, setItems] = useState(initialItems);
-  const [task, setTask] = useState('');
+  const [items, setItems] = useState<ChecklistItem[]>(initialItems);
+  const [task, setTask] = useState<string>("");
 
   const addItem = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!task.trim()) return;
     setItems([...items, { id: Date.now(), text: task.trim(), done: false }]);
-    setTask('');
+    setTask("");
   };
 
   const toggleItem = (id: number) => {
-    setItems(items.map((it) => (it.id === id ? { ...it, done: !it.done } : it)));
+    setItems(
+      items.map((it) => (it.id === id ? { ...it, done: !it.done } : it)),
+    );
   };
 
   return (
@@ -30,9 +38,13 @@ export default function Checklists() {
           id="task"
           type="text"
           value={task}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setTask(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setTask(e.target.value)
+          }
         />
-        <button type="submit" className="button">Add</button>
+        <button type="submit" className="button">
+          Add
+        </button>
       </form>
       <ul>
         {items.map((item) => (

--- a/pages/customers/index.tsx
+++ b/pages/customers/index.tsx
@@ -1,25 +1,36 @@
-import { useState } from 'react';
-import Layout from '../../components/Layout';
+import { useState } from "react";
+import Layout from "../../components/Layout";
 
-const sampleCustomers = [
+interface Customer {
+  id: number;
+  name: string;
+  org: string;
+  contact: {
+    name: string;
+    email: string;
+  };
+  assets: number;
+}
+
+const sampleCustomers: Customer[] = [
   {
     id: 1,
-    name: 'Acme Corp',
-    org: '123456789',
-    contact: { name: 'John Doe', email: 'john@example.com' },
+    name: "Acme Corp",
+    org: "123456789",
+    contact: { name: "John Doe", email: "john@example.com" },
     assets: 3,
   },
   {
     id: 2,
-    name: 'Globex LLC',
-    org: '987654321',
-    contact: { name: 'Jane Smith', email: 'jane@example.com' },
+    name: "Globex LLC",
+    org: "987654321",
+    contact: { name: "Jane Smith", email: "jane@example.com" },
     assets: 1,
   },
 ];
 
 export default function Customers() {
-  const [customers] = useState(sampleCustomers);
+  const [customers] = useState<Customer[]>(sampleCustomers);
 
   return (
     <Layout>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,27 +1,27 @@
-import { FormEvent, ChangeEvent, useState } from 'react';
-import { useRouter } from 'next/router';
-import { useAuth } from '../contexts/AuthContext';
-import '../styles/login.css';
+import { FormEvent, ChangeEvent, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "../contexts/AuthContext";
+import "../styles/login.css";
 
 export default function Login() {
   const router = useRouter();
   const { login } = useAuth() as any;
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [error, setError] = useState<string>("");
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!email || !password) {
-      setError('Please fill in both fields');
+      setError("Please fill in both fields");
       return;
     }
     const success = await login(email, password);
     if (success) {
-      setError('');
-      router.push('/');
+      setError("");
+      router.push("/");
     } else {
-      setError('Invalid email or password');
+      setError("Invalid email or password");
     }
   };
 
@@ -56,7 +56,9 @@ export default function Login() {
             />
           </div>
           {error && <p className="error">{error}</p>}
-          <button type="submit" className="button">Sign In</button>
+          <button type="submit" className="button">
+            Sign In
+          </button>
         </form>
         <p className="footer">Demo credentials: admin@example.com / admin123</p>
       </div>


### PR DESCRIPTION
## Summary
- add interfaces for customer, checklist, price list and calc results
- specify generics for primitive useState hooks
- type input event handlers

## Testing
- `npx prettier -w pages/admin/settings.tsx pages/calculations/cost.tsx pages/calculations/price.tsx pages/checklists/index.tsx pages/customers/index.tsx pages/login.tsx`
- `npx tsc --noEmit` *(fails: Cannot find module 'next/link', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6842f45953d0832ebbce9351304ce227