### PR TITLE
Fix global login styles

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import '../styles/login.css';
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '../contexts/AuthContext';
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,7 +1,6 @@
 import { FormEvent, ChangeEvent, useState } from "react";
 import { useRouter } from "next/router";
 import { useAuth } from "../contexts/AuthContext";
-import "../styles/login.css";
 
 export default function Login() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- apply login.css globally by importing in _app
- clean up login page imports

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498711a064832e99127c784432d2e6