### PR TITLE
Add ThingsBoard integration and env example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# ThingsBoard credentials for server-side API routes
+THINGSBOARD_CLIENT_ID=your-client-id
+THINGSBOARD_CLIENT_SECRET=your-client-secret
+THINGSBOARD_API_URL=https://thingsboard.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 out/
 node_modules/
 site/wwwroot/
+.env
+.env.local
+.env.*.local

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ This repository now provides a very small Next.js skeleton with placeholder page
 
 Visit `http://localhost:3000` to see the placeholder page.
 
+### ThingsBoard integration
+
+The app can load customers and users from a ThingsBoard instance. Copy
+`.env.local.example` to `.env.local` and fill in your ThingsBoard client ID,
+client secret and API URL:
+
+```bash
+cp .env.local.example .env.local
+# edit .env.local
+```
+
+These environment variables are read by the Next.js API routes to authenticate
+against ThingsBoard using the client credentials flow.
+
 ## Continuous Deployment
 
 The repository includes a GitHub Actions workflow that builds and deploys the

--- a/contexts/ThingsboardContext.tsx
+++ b/contexts/ThingsboardContext.tsx
@@ -1,0 +1,65 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface Customer {
+  id: string;
+  title: string;
+}
+
+interface TbUser {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+interface ThingsboardContextType {
+  customers: Customer[];
+  users: TbUser[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+const ThingsboardContext = createContext<ThingsboardContextType | undefined>(undefined);
+
+export function ThingsboardProvider({ children }: { children: ReactNode }) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [users, setUsers] = useState<TbUser[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [cRes, uRes] = await Promise.all([
+        fetch('/api/thingsboard/tenants'),
+        fetch('/api/thingsboard/users'),
+      ]);
+      if (cRes.ok) {
+        const data = await cRes.json();
+        setCustomers(data.data || data);
+      }
+      if (uRes.ok) {
+        const data = await uRes.json();
+        setUsers(data.data || data);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <ThingsboardContext.Provider value={{ customers, users, loading, refresh }}>
+      {children}
+    </ThingsboardContext.Provider>
+  );
+}
+
+export function useThingsboard(): ThingsboardContextType {
+  const ctx = useContext(ThingsboardContext);
+  if (!ctx) {
+    throw new Error('useThingsboard must be used within ThingsboardProvider');
+  }
+  return ctx;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,14 @@ import '../styles/globals.css';
 import '../styles/login.css';
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '../contexts/AuthContext';
+import { ThingsboardProvider } from '../contexts/ThingsboardContext';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <ThingsboardProvider>
+        <Component {...pageProps} />
+      </ThingsboardProvider>
     </AuthProvider>
   );
 }

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,32 +1,32 @@
 import Layout from '../../components/Layout';
-
-const sampleUsers = [
-  { id: 1, name: 'Admin User', email: 'admin@example.com', role: 'Admin' },
-  { id: 2, name: 'Regular User', email: 'user@example.com', role: 'User' }
-];
+import { useThingsboard } from '../../contexts/ThingsboardContext';
 
 export default function UserManagement() {
+  const { users, loading } = useThingsboard();
+
   return (
     <Layout>
       <h1>User Management</h1>
-      <table className="user-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Role</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sampleUsers.map((u) => (
-            <tr key={u.id}>
-              <td>{u.name}</td>
-              <td>{u.email}</td>
-              <td>{u.role}</td>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table className="user-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id}>
+                <td>{u.name || u.email}</td>
+                <td>{u.email}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </Layout>
   );
 }

--- a/pages/api/thingsboard/tenants.ts
+++ b/pages/api/thingsboard/tenants.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const baseUrl = process.env.THINGSBOARD_API_URL;
+  const clientId = process.env.THINGSBOARD_CLIENT_ID;
+  const clientSecret = process.env.THINGSBOARD_CLIENT_SECRET;
+
+  if (!baseUrl || !clientId || !clientSecret) {
+    return res
+      .status(500)
+      .json({ error: 'ThingsBoard credentials not configured' });
+  }
+
+  try {
+    const tokenResp = await fetch(`${baseUrl}/api/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'client_credentials',
+      }),
+    });
+
+    if (!tokenResp.ok) {
+      throw new Error('Failed to authenticate with ThingsBoard');
+    }
+
+    const { access_token } = await tokenResp.json();
+
+    const tenantsResp = await fetch(`${baseUrl}/api/tenants`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+
+    if (!tenantsResp.ok) {
+      throw new Error('Failed to fetch tenants');
+    }
+
+    const data = await tenantsResp.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}

--- a/pages/api/thingsboard/users.ts
+++ b/pages/api/thingsboard/users.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const baseUrl = process.env.THINGSBOARD_API_URL;
+  const clientId = process.env.THINGSBOARD_CLIENT_ID;
+  const clientSecret = process.env.THINGSBOARD_CLIENT_SECRET;
+
+  if (!baseUrl || !clientId || !clientSecret) {
+    return res
+      .status(500)
+      .json({ error: 'ThingsBoard credentials not configured' });
+  }
+
+  try {
+    const tokenResp = await fetch(`${baseUrl}/api/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'client_credentials',
+      }),
+    });
+
+    if (!tokenResp.ok) {
+      throw new Error('Failed to authenticate with ThingsBoard');
+    }
+
+    const { access_token } = await tokenResp.json();
+
+    const usersResp = await fetch(`${baseUrl}/api/users`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+
+    if (!usersResp.ok) {
+      throw new Error('Failed to fetch users');
+    }
+
+    const data = await usersResp.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}

--- a/pages/customers/index.tsx
+++ b/pages/customers/index.tsx
@@ -1,63 +1,32 @@
-import { useState } from "react";
 import Layout from "../../components/Layout";
-
-interface Customer {
-  id: number;
-  name: string;
-  org: string;
-  contact: {
-    name: string;
-    email: string;
-  };
-  assets: number;
-}
-
-const sampleCustomers: Customer[] = [
-  {
-    id: 1,
-    name: "Acme Corp",
-    org: "123456789",
-    contact: { name: "John Doe", email: "john@example.com" },
-    assets: 3,
-  },
-  {
-    id: 2,
-    name: "Globex LLC",
-    org: "987654321",
-    contact: { name: "Jane Smith", email: "jane@example.com" },
-    assets: 1,
-  },
-];
+import { useThingsboard } from "../../contexts/ThingsboardContext";
 
 export default function Customers() {
-  const [customers] = useState<Customer[]>(sampleCustomers);
+  const { customers, loading } = useThingsboard();
 
   return (
     <Layout>
       <h1>Customers</h1>
-      <table className="table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Org Number</th>
-            <th>Contact</th>
-            <th>Assets</th>
-          </tr>
-        </thead>
-        <tbody>
-          {customers.map((c) => (
-            <tr key={c.id}>
-              <td>{c.name}</td>
-              <td>{c.org}</td>
-              <td>
-                <div>{c.contact.name}</div>
-                <div className="small">{c.contact.email}</div>
-              </td>
-              <td>{c.assets}</td>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Customer Name</th>
+              <th>ID</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {customers.map((c) => (
+              <tr key={c.id}>
+                <td>{c.title}</td>
+                <td>{c.id}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- ignore `.env.local` files but keep `.env.local.example`
- document ThingsBoard environment variables in README
- load customers and users from ThingsBoard APIs
- wrap pages in `ThingsboardProvider`
- add API routes that authenticate to ThingsBoard using client credentials
- show tenants and users from ThingsBoard in pages

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849f828ec2c832ebab462477d702d3c