### PR TITLE
Add simple quote management

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { label: 'Dashboard', href: '/' },
   { label: 'Cost Calc', href: '/calculations/cost' },
   { label: 'Price Lists', href: '/calculations/price' },
+  { label: 'Quotes', href: '/quotes' },
   { label: 'Customers', href: '/customers' },
   { label: 'Checklists', href: '/checklists' },
   { label: 'Admin', href: '/admin' }

--- a/contexts/CustomerContext.tsx
+++ b/contexts/CustomerContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export interface Customer {
+  id: string;
+  name: string;
+  org?: string;
+  contact?: { name: string; email: string };
+  assets?: number;
+}
+
+interface CustomerContextType {
+  customers: Customer[];
+  addCustomer: (customer: Omit<Customer, 'id'>) => Customer;
+}
+
+const CustomerContext = createContext<CustomerContextType | undefined>(undefined);
+
+export function CustomerProvider({ children }: { children: ReactNode }) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('customers');
+      if (stored) setCustomers(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('customers', JSON.stringify(customers));
+    }
+  }, [customers]);
+
+  const addCustomer = (customer: Omit<Customer, 'id'>): Customer => {
+    const newCust = { id: Date.now().toString(), ...customer };
+    setCustomers(prev => [...prev, newCust]);
+    return newCust;
+  };
+
+  return (
+    <CustomerContext.Provider value={{ customers, addCustomer }}>
+      {children}
+    </CustomerContext.Provider>
+  );
+}
+
+export function useCustomers(): CustomerContextType {
+  const ctx = useContext(CustomerContext);
+  if (!ctx) throw new Error('useCustomers must be inside CustomerProvider');
+  return ctx;
+}

--- a/contexts/QuoteContext.tsx
+++ b/contexts/QuoteContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export interface QuoteItem {
+  id: string;
+  description: string;
+  price: number;
+  qty: number;
+}
+
+export interface Quote {
+  id: string;
+  name: string;
+  seller: string;
+  customerId: string;
+  customerName: string;
+  items: QuoteItem[];
+  total: number;
+}
+
+interface QuoteContextType {
+  quotes: Quote[];
+  addQuote: (quote: Quote) => void;
+}
+
+const QuoteContext = createContext<QuoteContextType | undefined>(undefined);
+
+export function QuoteProvider({ children }: { children: ReactNode }) {
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('quotes');
+      if (stored) setQuotes(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('quotes', JSON.stringify(quotes));
+    }
+  }, [quotes]);
+
+  const addQuote = (quote: Quote) => {
+    setQuotes(prev => [...prev, quote]);
+  };
+
+  return (
+    <QuoteContext.Provider value={{ quotes, addQuote }}>
+      {children}
+    </QuoteContext.Provider>
+  );
+}
+
+export function useQuotes(): QuoteContextType {
+  const ctx = useContext(QuoteContext);
+  if (!ctx) throw new Error('useQuotes must be inside QuoteProvider');
+  return ctx;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,17 @@ import '../styles/globals.css';
 import '../styles/login.css';
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '../contexts/AuthContext';
+import { CustomerProvider } from '../contexts/CustomerContext';
+import { QuoteProvider } from '../contexts/QuoteContext';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <CustomerProvider>
+        <QuoteProvider>
+          <Component {...pageProps} />
+        </QuoteProvider>
+      </CustomerProvider>
     </AuthProvider>
   );
 }

--- a/pages/customers/index.tsx
+++ b/pages/customers/index.tsx
@@ -1,36 +1,8 @@
-import { useState } from "react";
 import Layout from "../../components/Layout";
-
-interface Customer {
-  id: number;
-  name: string;
-  org: string;
-  contact: {
-    name: string;
-    email: string;
-  };
-  assets: number;
-}
-
-const sampleCustomers: Customer[] = [
-  {
-    id: 1,
-    name: "Acme Corp",
-    org: "123456789",
-    contact: { name: "John Doe", email: "john@example.com" },
-    assets: 3,
-  },
-  {
-    id: 2,
-    name: "Globex LLC",
-    org: "987654321",
-    contact: { name: "Jane Smith", email: "jane@example.com" },
-    assets: 1,
-  },
-];
+import { useCustomers } from "../../contexts/CustomerContext";
 
 export default function Customers() {
-  const [customers] = useState<Customer[]>(sampleCustomers);
+  const { customers } = useCustomers();
 
   return (
     <Layout>
@@ -48,12 +20,16 @@ export default function Customers() {
           {customers.map((c) => (
             <tr key={c.id}>
               <td>{c.name}</td>
-              <td>{c.org}</td>
+              <td>{c.org || ''}</td>
               <td>
-                <div>{c.contact.name}</div>
-                <div className="small">{c.contact.email}</div>
+                {c.contact && (
+                  <>
+                    <div>{c.contact.name}</div>
+                    <div className="small">{c.contact.email}</div>
+                  </>
+                )}
               </td>
-              <td>{c.assets}</td>
+              <td>{c.assets || ''}</td>
             </tr>
           ))}
         </tbody>

--- a/pages/quotes/index.tsx
+++ b/pages/quotes/index.tsx
@@ -1,0 +1,33 @@
+import Layout from '../../components/Layout';
+import { useQuotes } from '../../contexts/QuoteContext';
+
+export default function QuoteList() {
+  const { quotes } = useQuotes();
+
+  return (
+    <Layout>
+      <h1>Saved Quotes</h1>
+      <p>
+        <a href="/quotes/new">Create New Quote</a>
+      </p>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Seller</th>
+            <th>Customer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {quotes.map(q => (
+            <tr key={q.id}>
+              <td>{q.name}</td>
+              <td>{q.seller}</td>
+              <td>{q.customerName}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Layout>
+  );
+}

--- a/pages/quotes/new.tsx
+++ b/pages/quotes/new.tsx
@@ -1,0 +1,123 @@
+import { ChangeEvent, useState } from 'react';
+import Layout from '../../components/Layout';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCustomers } from '../../contexts/CustomerContext';
+import { useQuotes } from '../../contexts/QuoteContext';
+
+interface PriceItem {
+  id: string;
+  description: string;
+  price: number;
+  qty: number;
+}
+
+const defaultItems: PriceItem[] = [
+  { id: '1', description: 'Grunpakke AES (pr bygg)', price: 2880, qty: 0 },
+  { id: '2', description: 'Ekstra Ethub målepunkt', price: 1440, qty: 0 },
+  { id: '3', description: 'Gateway for sensorer', price: 720, qty: 0 },
+];
+
+export default function NewQuote() {
+  const { user } = useAuth();
+  const { customers, addCustomer } = useCustomers();
+  const { addQuote } = useQuotes();
+
+  const [items, setItems] = useState<PriceItem[]>(defaultItems);
+  const [showForm, setShowForm] = useState(false);
+  const [quoteName, setQuoteName] = useState('');
+  const [customerId, setCustomerId] = useState('');
+  const [newCustomer, setNewCustomer] = useState('');
+
+  const updateQty = (id: string, qty: number) => {
+    setItems(items.map(it => (it.id === id ? { ...it, qty } : it)));
+  };
+
+  const total = items.reduce((sum, it) => sum + it.price * it.qty, 0);
+
+  const saveQuote = () => {
+    let custId = customerId;
+    let custName = '';
+    if (customerId === 'new') {
+      const c = addCustomer({ name: newCustomer });
+      custId = c.id;
+      custName = c.name;
+    } else {
+      const c = customers.find(c => c.id === customerId);
+      custName = c?.name || '';
+    }
+
+    addQuote({
+      id: Date.now().toString(),
+      name: quoteName,
+      seller: user?.name || '',
+      customerId: custId,
+      customerName: custName,
+      items: items.filter(i => i.qty > 0),
+      total,
+    });
+    setShowForm(false);
+  };
+
+  return (
+    <Layout>
+      <h1>Create Quote</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th>Price / year</th>
+            <th>Qty</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(it => (
+            <tr key={it.id}>
+              <td>{it.description}</td>
+              <td>{it.price} kr</td>
+              <td>
+                <input
+                  type="number"
+                  value={it.qty}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    updateQty(it.id, parseInt(e.target.value) || 0)
+                  }
+                  style={{ width: '60px' }}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>Total: {total} kr / year</p>
+
+      <button className="button" onClick={() => window.print()}>Print / PDF</button>
+      <button className="button" onClick={() => setShowForm(true)} style={{ marginLeft: '8px' }}>Save Quote</button>
+
+      {showForm && (
+        <div style={{ marginTop: '20px' }}>
+          <div className="form-group">
+            <label>Quote Name</label>
+            <input value={quoteName} onChange={e => setQuoteName(e.target.value)} />
+          </div>
+          <div className="form-group">
+            <label>Customer</label>
+            <select value={customerId} onChange={e => setCustomerId(e.target.value)}>
+              <option value="">Select...</option>
+              {customers.map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+              <option value="new">New Customer</option>
+            </select>
+          </div>
+          {customerId === 'new' && (
+            <div className="form-group">
+              <label>New Customer Name</label>
+              <input value={newCustomer} onChange={e => setNewCustomer(e.target.value)} />
+            </div>
+          )}
+          <button className="button" onClick={saveQuote}>Save</button>
+        </div>
+      )}
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add Customers and Quotes contexts for storage in localStorage
- wire new providers in `_app`
- extend navigation with a Quotes link
- update Customers page to use context data
- add pages to create and list quotes

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849fa6031bc832eb902bffea667ef90