### PR TITLE
Fix safe access for user name

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -28,7 +28,7 @@ export default function Layout({ children }: LayoutProps) {
           ))}
           {isAuthenticated ? (
             <button onClick={logout} className="nav-link button-logout">
-              Sign Out ({user.name})
+              Sign Out ({user?.name})
             </button>
           ) : (
             <Link href="/login" className="nav-link">Login</Link>


### PR DESCRIPTION
## Summary
- avoid accessing `user.name` when `user` can be null

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849fb3c643c832eb78b73cdccd86e8a