### PR TITLE
Fix safe access for user name

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -16,7 +16,7 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const { isAuthenticated, user, logout } = useAuth();
+  const { isAuthenticated, user: authUser, logout } = useAuth();
   return (
     <>
       <header className="header">
@@ -28,7 +28,7 @@ export default function Layout({ children }: LayoutProps) {
           ))}
           {isAuthenticated ? (
             <button onClick={logout} className="nav-link button-logout">
-              Sign Out ({user.name})
+              Sign Out ({authUser?.name})
             </button>
           ) : (
             <Link href="/login" className="nav-link">Login</Link>

--- a/pages/checklists/index.tsx
+++ b/pages/checklists/index.tsx
@@ -13,7 +13,7 @@ interface Checklist {
 const STORAGE_KEY = "checklists";
 
 export default function Checklists() {
-  const { user } = useAuth();
+  const { user: authUser } = useAuth();
   const [checklists, setChecklists] = useState<Checklist[]>([]);
   const [editTitles, setEditTitles] = useState<Record<number, string>>({});
 
@@ -45,7 +45,7 @@ export default function Checklists() {
         return {
           ...c,
           done: true,
-          doneBy: user?.name || "Unknown",
+          doneBy: authUser?.name || "Unknown",
           doneAt: new Date().toISOString(),
         };
       }),


### PR DESCRIPTION
## Summary
- avoid accessing `user.name` when `user` can be null
- rename `user` variable to `authUser` for clarity

## Testing
- `npm run build` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: JSX element implicitly has type 'any')*

------
https://chatgpt.com/codex/tasks/task_b_6849fb3c643c832eb78b73cdccd86e8a