### PR TITLE
Improve Thingsboard refresh error handling

### DIFF
--- a/contexts/ThingsboardContext.tsx
+++ b/contexts/ThingsboardContext.tsx
@@ -32,21 +32,25 @@ export function ThingsboardProvider({ children }: { children: ReactNode }) {
         fetch('/api/thingsboard/tenants'),
         fetch('/api/thingsboard/users'),
       ]);
-      if (cRes.ok) {
-        const data = await cRes.json();
-        setCustomers(data.data || data);
+
+      if (!cRes.ok || !uRes.ok) {
+        throw new Error('Failed to fetch Thingsboard data');
       }
-      if (uRes.ok) {
-        const data = await uRes.json();
-        setUsers(data.data || data);
-      }
+
+      const cData = await cRes.json();
+      const uData = await uRes.json();
+
+      setCustomers(cData.data || cData);
+      setUsers(uData.data || uData);
+    } catch (err) {
+      console.error('Error refreshing Thingsboard data:', err);
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
-    refresh();
+    refresh().catch(err => console.error('Unhandled refresh error:', err));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add error handling for Thingsboard context refresh
- prevent unhandled refresh promise rejections

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a01fb262c832e80124bcffb45b882