### PR TITLE
Refactor ThingsBoard API auth

### DIFF
--- a/pages/api/thingsboard/tenants.ts
+++ b/pages/api/thingsboard/tenants.ts
@@ -1,35 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getThingsboardToken } from '../../../utils/thingsboard';
 
 export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
   const baseUrl = process.env.THINGSBOARD_API_URL;
-  const clientId = process.env.THINGSBOARD_CLIENT_ID;
-  const clientSecret = process.env.THINGSBOARD_CLIENT_SECRET;
 
-  if (!baseUrl || !clientId || !clientSecret) {
+  if (!baseUrl) {
     return res
       .status(500)
       .json({ error: 'ThingsBoard credentials not configured' });
   }
 
   try {
-    const tokenResp = await fetch(`${baseUrl}/api/oauth/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        client_id: clientId,
-        client_secret: clientSecret,
-        grant_type: 'client_credentials',
-      }),
-    });
-
-    if (!tokenResp.ok) {
-      throw new Error('Failed to authenticate with ThingsBoard');
-    }
-
-    const { access_token } = await tokenResp.json();
+    const access_token = await getThingsboardToken();
 
     const tenantsResp = await fetch(`${baseUrl}/api/tenants`, {
       headers: { Authorization: `Bearer ${access_token}` },

--- a/pages/api/thingsboard/users.ts
+++ b/pages/api/thingsboard/users.ts
@@ -1,35 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getThingsboardToken } from '../../../utils/thingsboard';
 
 export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
   const baseUrl = process.env.THINGSBOARD_API_URL;
-  const clientId = process.env.THINGSBOARD_CLIENT_ID;
-  const clientSecret = process.env.THINGSBOARD_CLIENT_SECRET;
 
-  if (!baseUrl || !clientId || !clientSecret) {
+  if (!baseUrl) {
     return res
       .status(500)
       .json({ error: 'ThingsBoard credentials not configured' });
   }
 
   try {
-    const tokenResp = await fetch(`${baseUrl}/api/oauth/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        client_id: clientId,
-        client_secret: clientSecret,
-        grant_type: 'client_credentials',
-      }),
-    });
-
-    if (!tokenResp.ok) {
-      throw new Error('Failed to authenticate with ThingsBoard');
-    }
-
-    const { access_token } = await tokenResp.json();
+    const access_token = await getThingsboardToken();
 
     const usersResp = await fetch(`${baseUrl}/api/users`, {
       headers: { Authorization: `Bearer ${access_token}` },

--- a/utils/thingsboard.ts
+++ b/utils/thingsboard.ts
@@ -1,0 +1,30 @@
+export async function getThingsboardToken(): Promise<string> {
+  const baseUrl = process.env.THINGSBOARD_API_URL;
+  const clientId = process.env.THINGSBOARD_CLIENT_ID;
+  const clientSecret = process.env.THINGSBOARD_CLIENT_SECRET;
+
+  if (!baseUrl || !clientId || !clientSecret) {
+    throw new Error('ThingsBoard credentials not configured');
+  }
+
+  const tokenResp = await fetch(`${baseUrl}/api/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'client_credentials',
+    }),
+  });
+
+  if (!tokenResp.ok) {
+    throw new Error('Failed to authenticate with ThingsBoard');
+  }
+
+  const { access_token } = await tokenResp.json();
+  if (!access_token) {
+    throw new Error('No access token received from ThingsBoard');
+  }
+
+  return access_token as string;
+}


### PR DESCRIPTION
## Summary
- centralize OAuth token retrieval in `utils/thingsboard.ts`
- use the helper in `users` and `tenants` API routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a01fb9f9c832e921576d1894679a9