### PR TITLE
Rename ThingsBoard customer type

### DIFF
--- a/contexts/ThingsboardContext.tsx
+++ b/contexts/ThingsboardContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
-interface Customer {
+interface TbCustomer {
   id: string;
   title: string;
 }
@@ -12,7 +12,7 @@ interface TbUser {
 }
 
 interface ThingsboardContextType {
-  customers: Customer[];
+  customers: TbCustomer[];
   users: TbUser[];
   loading: boolean;
   refresh: () => Promise<void>;
@@ -21,7 +21,7 @@ interface ThingsboardContextType {
 const ThingsboardContext = createContext<ThingsboardContextType | undefined>(undefined);
 
 export function ThingsboardProvider({ children }: { children: ReactNode }) {
-  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [customers, setCustomers] = useState<TbCustomer[]>([]);
   const [users, setUsers] = useState<TbUser[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 


### PR DESCRIPTION
## Summary
- rename the ThingsBoard `Customer` interface to `TbCustomer`
- update internal state and context typings

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a01fc6624832e98467935730b6bd9